### PR TITLE
feat(ScrollSpy): Allow setting debounce on ScrollSpySectionComponent

### DIFF
--- a/src/lib/src/scroll-spy-section/scroll-spy-section.component.html
+++ b/src/lib/src/scroll-spy-section/scroll-spy-section.component.html
@@ -2,6 +2,6 @@
   class="sn-hidden"
   snInViewport
   (onInViewportChange)="onInViewportChange($event)"
-  [debounce]="0">
+  [debounce]="debounce">
 </div>
 <ng-content></ng-content>

--- a/src/lib/src/scroll-spy-section/scroll-spy-section.component.ts
+++ b/src/lib/src/scroll-spy-section/scroll-spy-section.component.ts
@@ -38,6 +38,16 @@ export class ScrollSpySectionComponent {
   @Input()
   public for: string;
   /**
+   * Amount of time in ms to wait for other scroll events
+   * before running event handler
+   *
+   * @type {number}
+   * @default 0
+   * @memberof ScrollSpySectionComponent
+   */
+  @Input()
+  public debounce = 0;
+  /**
    * Creates an instance of ScrollSpySectionComponent.
    * @param {ScrollSpyService} scrollSpySvc
    * @param {ChangeDetectorRef} cdRef


### PR DESCRIPTION
I noticed `debounce` was hardcoded to 0 in the `<sn-scroll-spy-section>` component. This change makes it configurable via an input property.